### PR TITLE
SITL: allow setting jsbsim_ext sim rate multiplier

### DIFF
--- a/libraries/SITL/SIM_JSBSimExt.h
+++ b/libraries/SITL/SIM_JSBSimExt.h
@@ -47,6 +47,7 @@ public:
         return new JSBSimExt(frame_str);
     }
 
+    void set_config(const char* config) override;
     void set_interface_ports(const char* address, const int port_in, const int port_out) override;
 
 private:
@@ -65,6 +66,7 @@ private:
 
     // default JSBSim model
     const char *jsbsim_model = "Rascal";
+    int jsbsim_rate_multiplier = 1;
 
     bool created_templates;
     bool opened_control_socket;


### PR DESCRIPTION
I noticed recently that the OpenSUT autopilot is completely non-functional - instead of initializing sensors in a few seconds and letting the user start the mission, it slowly initializes them over the course of several hours (I ran it for 3+ hours and it never reached the "pre-arm good" state) while constantly dropping the connection to MAVproxy.  After several days of debugging and a bit of archeology, I found this commit on my old laptop, which apparently I forgot to push when creating #1.  Adding this commit fixes the bug.

The actual change in this commit is to allow the JSBSim update rate to be an integer multiple of the autopilot's update rate.  The performance overhead of the OpenSUT's nested VM setup means the autopilot update rate can't exceed ~300 Hz, but JSBSim's update rate must be at least 400 Hz (ideally much higher) or else the simulation becomes unstable.  To work around this, we run JSBSim at 2500 Hz and run the autopilot at 250 Hz with a sim rate multiplier of 10x.  The autopilot needs to be aware of the sim rate multiplier because the autopilot itself is responsible for driving the simulation - it periodically sends commands to JSBSim instructing it to advance the simulation by a certain amount.

I haven't fully investigated the previous bug, but my guess is that the autopilot was timing out waiting for updates from JSBSim.  The autopilot was expecting an update after each step, but JSBSim was sending updates only every 10 steps.